### PR TITLE
Add support for multiple entities

### DIFF
--- a/.github/workflows/sub_publish_ghregistry.yaml
+++ b/.github/workflows/sub_publish_ghregistry.yaml
@@ -76,7 +76,8 @@ jobs:
         
         Publish-Module -Path ./src/SitecoreCecSearchModule `
           -Repository $repositoryName `
-          -NuGetApiKey "${{ github.token }}"
+          -NuGetApiKey "${{ github.token }}" `
+          -SkipAutomaticTags
 
   # verify:
   #   name: Verify published package

--- a/.github/workflows/sub_version.yaml
+++ b/.github/workflows/sub_version.yaml
@@ -43,7 +43,7 @@ jobs:
 
         $no = $versions.CommitsSinceVersionSourcePadded
         $version = $versions.MajorMinorPatch
-        $prerelease = ("{0}" -f $versions.NuGetPreReleaseTagV2)
+        $prerelease = ("{0}" -f $versions.NuGetPreReleaseTagV2.Replace("-", ""))
         $branch = $versions.PreReleaseLabel
 
         $fullversion = (@($version, $prerelease) | Where-object { $_ -ne "" }) -join "-"

--- a/bld/GitVersion.yml
+++ b/bld/GitVersion.yml
@@ -8,5 +8,7 @@ branches:
     tag: beta
   pull-request:
     tag: alphapr{Number} 
+    mode: ContinuousDeployment
   feature:
     tag: alpha{BranchName}
+    mode: ContinuousDeployment

--- a/src/SitecoreCecSearchModule/SitecoreCecSearchModule.psd1
+++ b/src/SitecoreCecSearchModule/SitecoreCecSearchModule.psd1
@@ -105,7 +105,11 @@
     'Get-CecJobError',
 
     'Get-CecEntityConfig',
+    'Set-CecEntityConfig',
     'Write-CecEntityConfig',
+    'Read-CecEntityConfig',
+    'Publish-CecEntityConfig',
+    'Remove-CecEntityConfigDraft',
     'Get-CecAttribute',
     'Set-CecAttribute',
     'Write-CecAttribute',
@@ -134,7 +138,8 @@
     'Invoke-GetAndWriteCecConnectorConfiguration',
 
     'Convert-HttpJsonToGraph',
-    'Convert-HttpGraphToJson'
+    'Convert-HttpGraphToJson',
+    'Set-CecClientDefaultProperties'
     
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport      = @()

--- a/src/SitecoreCecSearchModule/SitecoreCecSearchModule.psd1
+++ b/src/SitecoreCecSearchModule/SitecoreCecSearchModule.psd1
@@ -116,7 +116,9 @@
     'Read-CecAttribute',
     'Get-CecSpec',
     'Get-CecEntity',
+    'Set-CecEntity',
     'Write-CecEntity',
+    'Read-CecEntity',
 
     'Get-CecFeatureConfig',
     'Write-CecFeatureConfig',

--- a/src/SitecoreCecSearchModule/functions/aggregated.ps1
+++ b/src/SitecoreCecSearchModule/functions/aggregated.ps1
@@ -8,14 +8,22 @@ function Invoke-GetAndWriteAllCecConfiguration {
         [string]$Prefix,
         [string]$TextToken,
         [string]$ScriptToken,
+        [string]$EntityPrefix,
+        [string]$EntitySuffix,
         $Domains,
         [Switch]$SkipConnectorReplacement
     )
 
-    Get-CecEntityConfig | Write-CecEntityConfig -Path (Join-Path $Path "entities") -Force
-    Get-CecEntity | Write-CecEntity -Path (Join-Path $Path "entities") -Force
+    Get-CecEntityConfig -EntityPrefix:$EntityPrefix -EntitySuffix:$EntitySuffix -RemovePrefix | Write-CecEntityConfig -Path (Join-Path $Path "entities") -Force
+    Get-CecEntity -EntityPrefix:$EntityPrefix -EntitySuffix:$EntitySuffix -RemovePrefix | Write-CecEntity -Path (Join-Path $Path "entities") -Force
 
-    Invoke-GetAndWriteCecConnectorConfiguration -Path:$Path -EnvToken:$EnvToken -Suffix:$Suffix -Prefix:$Prefix -TextToken:$TextToken -ScriptToken:$ScriptToken -Domains:$Domains -SkipConnectorReplacement:$SkipConnectorReplacement
+    Invoke-GetAndWriteCecConnectorConfiguration -Path:$Path `
+        -EnvToken:$EnvToken `
+        -Suffix:$Suffix -Prefix:$Prefix `
+        -TextToken:$TextToken -ScriptToken:$ScriptToken `
+        -Domains:$Domains `
+        -SkipConnectorReplacement:$SkipConnectorReplacement `
+        -EntityPrefix:$EntityPrefix -EntitySuffix:$EntitySuffix
 
     Get-CecFeatureConfig | Write-CecFeatureConfig -Path $Path
 
@@ -37,7 +45,10 @@ function Invoke-GetAndWriteCecConnectorConfiguration {
         [string]$TextToken,
         [string]$ScriptToken,
         $Domains,
-        [Switch]$SkipConnectorReplacement
+        [Switch]$SkipConnectorReplacement,
+        [string]$EntityPrefix,
+        [string]$EntitySuffix
+
     )
 
     if ("${EnvToken}" -ne "" -and "${Suffix}" -eq "" -and "${Prefix}" -eq "" -and "${TextToken}" -eq "" -and "${ScriptToken}" -eq "") {
@@ -49,7 +60,7 @@ function Invoke-GetAndWriteCecConnectorConfiguration {
     $connectorsPath = Join-Path $Path "connectors"
     $connectors = Get-CecConnectorInfo -Suffix $Suffix -Prefix $Prefix | Get-CecConnector
     if (-not $SkipConnectorReplacement) {
-        $connectors = $connectors | Remove-CecConnectorPrefix -Suffix:$Suffix -Prefix:$Prefix -TextToken:$TextToken -ScriptToken:$ScriptToken -Domains:$Domains
+        $connectors = $connectors | Remove-CecConnectorPrefix -Suffix:$Suffix -Prefix:$Prefix -TextToken:$TextToken -ScriptToken:$ScriptToken -Domains:$Domains -EntityPrefix:$EntityPrefix -EntitySuffix:$EntitySuffix
         $connectors = $connectors | Remove-CecConnectorVercelBypassProtection
     }
 

--- a/src/SitecoreCecSearchModule/functions/attributes-client.ps1
+++ b/src/SitecoreCecSearchModule/functions/attributes-client.ps1
@@ -57,17 +57,19 @@ function Set-CecEntityConfig {
         }
     }
 
-    $doc.domainConfig.version += 1
-    $doc.domainConfig.updatedAt = ([long](Get-Date -AsUTC -UFormat "%s")) * 1000
-    $doc.domainConfig | AddOrSetPropertyValue -PropertyName "status" -Value "draft"
-    $doc.domainConfig | AddOrSetPropertyValue -PropertyName "operation" -Value "UPDATE"
     $doc.domainConfig.PSObject.Properties.Remove("createdAt")
     $doc.domainConfig.PSObject.Properties.Remove("live")
+    if ($doc.domainConfig.status -ne "draft") {
+        $doc.domainConfig.version += 1
+        $doc.domainConfig | AddOrSetPropertyValue -PropertyName "status" -Value "draft"
+    }
+    $doc.domainConfig.updatedAt = ([long](Get-Date -AsUTC -UFormat "%s")) * 1000
+    $doc.domainConfig | AddOrSetPropertyValue -PropertyName "operation" -Value "UPDATE"
 
     if ($Force -or $PSCmdlet.ShouldProcess("SitecoreCeCSearch", 'Send request to service')) {
 
         $response = (Invoke-CecDomainMethod -Method PUT -Path $configRequestPath -Body ($doc.domainConfig)) | Select-Object -ExpandProperty "domainConfig"
-        if($Publish) {
+        if ($Publish) {
             $response = Publish-CecEntityConfig
         }
 

--- a/src/SitecoreCecSearchModule/functions/attributes-client.ps1
+++ b/src/SitecoreCecSearchModule/functions/attributes-client.ps1
@@ -156,26 +156,28 @@ function Set-CecEntity {
         [Switch]$Force
     )
 
-    $doc = (Invoke-CecDomainMethod -Method GET -Path $specsRequestPath)
-    $currentEntities = $doc.productSpecs.attributesV2
+    process {
+        $doc = (Invoke-CecDomainMethod -Method GET -Path $specsRequestPath)
+        $currentEntities = $doc.productSpecs.attributesV2
 
-    $names = $Entities.PSObject.Properties.Name
-    foreach ($name in $names) {
-        $newName = $name
-        if ($AddPrefix) {
-            $newName = Add-Suffix -Value $newName -Prefix $Prefix -Suffix $Suffix
+        $names = $Entities.PSObject.Properties.Name
+        foreach ($name in $names) {
+            $newName = $name
+            if ($AddPrefix) {
+                $newName = Add-Suffix -Value $newName -Prefix $Prefix -Suffix $Suffix
+            }
+
+            $currentEntities | AddOrSetPropertyValue -PropertyName $newName -Value $Entities.$name
+
+            $doc.productSpecs.attributesV2.$newName.items = $Entities.$name.items
         }
 
-        $currentEntities | AddOrSetPropertyValue -PropertyName $newName -Value $Entities.$name
-
-        $doc.productSpecs.attributesV2.$newName.items = $Entities.$name.items
-    }
-
-    if ($Force -or $PSCmdlet.ShouldProcess("SitecoreCeCSearch", 'Send request to service')) {
-        Invoke-CecDomainMethod -Method PUT -Path $specsRequestPath -Body $doc
-    }
-    else {
-        $currentEntities
+        if ($Force -or $PSCmdlet.ShouldProcess("SitecoreCeCSearch", 'Send request to service')) {
+            Invoke-CecDomainMethod -Method PUT -Path $specsRequestPath -Body $doc
+        }
+        else {
+            $currentEntities
+        }
     }
 }
 

--- a/src/SitecoreCecSearchModule/functions/attributes-manipulation.ps1
+++ b/src/SitecoreCecSearchModule/functions/attributes-manipulation.ps1
@@ -7,10 +7,12 @@
         [string]$Suffix = $Null
     )
 
-    $Entity.displayName = Add-SuffixTemplate -Value $Entity.displayName -Prefix $Prefix -Suffix $Suffix
-    $Entity.name = Add-SuffixTemplate -Value $Entity.name -Prefix "${Prefix}".ToLower() -Suffix "${Suffix}".ToLower()
+    process {
+        $Entity.displayName = Add-SuffixTemplate -Value $Entity.displayName -Prefix $Prefix -Suffix $Suffix
+        $Entity.name = Add-SuffixTemplate -Value $Entity.name -Prefix "${Prefix}".ToLower() -Suffix "${Suffix}".ToLower()
 
-    $Entity
+        $Entity
+    }
 }
 
 function Set-CecEntityConfigSuffixValue {
@@ -22,8 +24,11 @@ function Set-CecEntityConfigSuffixValue {
         [string]$Suffix = $Null
     )
 
-    $Entity.displayName = Set-SuffixTemplateValues -Value $Entity.displayName -Prefix $Prefix -Suffix $Suffix
-    $Entity.name = Set-SuffixTemplateValues -Value $Entity.name -Prefix "${Prefix}".ToLower() -Suffix "${Suffix}".ToLower()
+    process {
 
-    $Entity
+        $Entity.displayName = Set-SuffixTemplateValues -Value $Entity.displayName -Prefix $Prefix -Suffix $Suffix
+        $Entity.name = Set-SuffixTemplateValues -Value $Entity.name -Prefix "${Prefix}".ToLower() -Suffix "${Suffix}".ToLower()
+
+        $Entity
+    }
 }

--- a/src/SitecoreCecSearchModule/functions/attributes-manipulation.ps1
+++ b/src/SitecoreCecSearchModule/functions/attributes-manipulation.ps1
@@ -1,0 +1,29 @@
+﻿function Set-CecEntityConfigSuffixTemplate {
+    param(
+        [Parameter(ValueFromPipeline, Mandatory)]
+        $Entity,
+
+        [string]$Prefix = $Null,
+        [string]$Suffix = $Null
+    )
+
+    $Entity.displayName = Add-SuffixTemplate -Value $Entity.displayName -Prefix $Prefix -Suffix $Suffix
+    $Entity.name = Add-SuffixTemplate -Value $Entity.name -Prefix "${Prefix}".ToLower() -Suffix "${Suffix}".ToLower()
+
+    $Entity
+}
+
+function Set-CecEntityConfigSuffixValue {
+    param(
+        [Parameter(ValueFromPipeline, Mandatory)]
+        $Entity,
+
+        [string]$Prefix = $Null,
+        [string]$Suffix = $Null
+    )
+
+    $Entity.displayName = Set-SuffixTemplateValues -Value $Entity.displayName -Prefix $Prefix -Suffix $Suffix
+    $Entity.name = Set-SuffixTemplateValues -Value $Entity.name -Prefix "${Prefix}".ToLower() -Suffix "${Suffix}".ToLower()
+
+    $Entity
+}

--- a/src/SitecoreCecSearchModule/functions/attributes-manipulation.ps1
+++ b/src/SitecoreCecSearchModule/functions/attributes-manipulation.ps1
@@ -1,4 +1,5 @@
 ﻿function Set-CecEntityConfigSuffixTemplate {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'false positive')]
     param(
         [Parameter(ValueFromPipeline, Mandatory)]
         $Entity,
@@ -16,6 +17,7 @@
 }
 
 function Set-CecEntityConfigSuffixValue {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'false positive')]
     param(
         [Parameter(ValueFromPipeline, Mandatory)]
         $Entity,
@@ -26,8 +28,8 @@ function Set-CecEntityConfigSuffixValue {
 
     process {
 
-        $Entity.displayName = Set-SuffixTemplateValues -Value $Entity.displayName -Prefix $Prefix -Suffix $Suffix
-        $Entity.name = Set-SuffixTemplateValues -Value $Entity.name -Prefix "${Prefix}".ToLower() -Suffix "${Suffix}".ToLower()
+        $Entity.displayName = Set-SuffixTemplateValue -Value $Entity.displayName -Prefix $Prefix -Suffix $Suffix
+        $Entity.name = Set-SuffixTemplateValue -Value $Entity.name -Prefix "${Prefix}".ToLower() -Suffix "${Suffix}".ToLower()
 
         $Entity
     }

--- a/src/SitecoreCecSearchModule/functions/attributes-serialization.ps1
+++ b/src/SitecoreCecSearchModule/functions/attributes-serialization.ps1
@@ -14,7 +14,7 @@
     }
 
     process {
-        $folderName = $_.name.Replace("{Prefix}","").Replace("{Suffix}", "")
+        $folderName = $_.name.Replace("{Prefix}", "").Replace("{Suffix}", "")
         $targetPath = Join-Path $Path "${folderName}/entity.json"
         if ($Force -or $PSCmdlet.ShouldProcess($Path, "Write entities config to disk ${targetPath}")) {
             Set-Content -Path $targetPath -Value (ConvertTo-Json -InputObject $_ -Depth 30)
@@ -28,9 +28,11 @@ function Read-CecEntityConfig {
         $Path
     )
 
-    [Array]$result = Get-ChildItem $Path -Recurse -Depth 2 -Filter "entity.json" | ForEach-Object { Get-Content $_ | ConvertFrom-Json }
+    process {
+        [Array]$result = Get-ChildItem $Path -Recurse -Depth 2 -Filter "entity.json" | ForEach-Object { Get-Content $_ | ConvertFrom-Json }
 
-    $result
+        $result
+    }
 }
 
 function Write-CecEntity {
@@ -61,7 +63,7 @@ function Write-CecEntity {
         }
 
         $names = $Entities.PSObject.Properties.Name
-        foreach($entityName in $names) {
+        foreach ($entityName in $names) {
             $folderPath = Join-Path $Path $entityName
             $attributes = $Entities.$entityName
             Write-CecAttribute -Attributes $attributes -Path $folderPath -SkipFiles:$SkipFiles -Force:$Force
@@ -77,7 +79,7 @@ function Read-CecEntity {
 
     $names = Get-ChildItem $Path -Directory | Select-Object -ExpandProperty Name
     $result = [PSCustomObject]@{  }
-    foreach($entityName in $names) {
+    foreach ($entityName in $names) {
         $folderPath = Join-Path $Path $entityName
         $attributes = Read-CecAttribute -Path $folderPath -SkipFiles:$SkipFiles
         $result | AddOrSetPropertyValue -PropertyName $entityName -Value $attributes

--- a/src/SitecoreCecSearchModule/functions/attributes-serialization.ps1
+++ b/src/SitecoreCecSearchModule/functions/attributes-serialization.ps1
@@ -20,6 +20,18 @@
     }
 }
 
+function Read-CecEntityConfig {
+    param(
+        [Parameter(ValueFromPipeline, Mandatory)]
+        $Path
+    )
+
+    [Array]$config = Get-Content -Path (Join-Path $Path "entities.json") | ConvertFrom-Json
+
+    $config
+
+}
+
 function Write-CecEntity {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(

--- a/src/SitecoreCecSearchModule/functions/attributes-serialization.ps1
+++ b/src/SitecoreCecSearchModule/functions/attributes-serialization.ps1
@@ -1,7 +1,7 @@
 ﻿function Write-CecEntityConfig {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
-        [Parameter(ValueFromPipeline, Mandatory)][Array]$Entities,
+        [Parameter(ValueFromPipeline, Mandatory)][Array]$Entity,
         [Parameter(Mandatory)][String]$Path,
 
         [Switch]$Force
@@ -14,8 +14,10 @@
     }
 
     process {
-        if ($Force -or $PSCmdlet.ShouldProcess($Path, 'Write entities config to disk')) {
-            Set-Content -Path (Join-Path $Path "entities.json") -Value (ConvertTo-Json -InputObject $Entities -Depth 30)
+        $folderName = $_.name.Replace("{Prefix}","").Replace("{Suffix}", "")
+        $targetPath = Join-Path $Path "${folderName}/entity.json"
+        if ($Force -or $PSCmdlet.ShouldProcess($Path, "Write entities config to disk ${targetPath}")) {
+            Set-Content -Path $targetPath -Value (ConvertTo-Json -InputObject $_ -Depth 30)
         }
     }
 }
@@ -26,10 +28,9 @@ function Read-CecEntityConfig {
         $Path
     )
 
-    [Array]$config = Get-Content -Path (Join-Path $Path "entities.json") | ConvertFrom-Json
+    [Array]$result = Get-ChildItem $Path -Recurse -Depth 2 -Filter "entity.json" | ForEach-Object { Get-Content $_ | ConvertFrom-Json }
 
-    $config
-
+    $result
 }
 
 function Write-CecEntity {
@@ -66,6 +67,23 @@ function Write-CecEntity {
             Write-CecAttribute -Attributes $attributes -Path $folderPath -SkipFiles:$SkipFiles -Force:$Force
         }
     }
+}
+
+function Read-CecEntity {
+    param(
+        [Parameter(Mandatory)][String]$Path,
+        [Switch]$SkipFiles
+    )
+
+    $names = Get-ChildItem $Path -Directory | Select-Object -ExpandProperty Name
+    $result = [PSCustomObject]@{  }
+    foreach($entityName in $names) {
+        $folderPath = Join-Path $Path $entityName
+        $attributes = Read-CecAttribute -Path $folderPath -SkipFiles:$SkipFiles
+        $result | AddOrSetPropertyValue -PropertyName $entityName -Value $attributes
+    }
+
+    $result
 }
 
 function Write-CecAttribute {

--- a/src/SitecoreCecSearchModule/functions/connectors-manipulation.ps1
+++ b/src/SitecoreCecSearchModule/functions/connectors-manipulation.ps1
@@ -11,7 +11,6 @@ function Add-CecConnectorPrefix {
         [String]$DomainReplacement = "https://domain",
         [String]$ScriptReplacement = "{ENV}",
         [String]$TextReplacement = "{ENV}",
-        [Switch]$Entities,
         [Hashtable]$Domains = @{}
     )
 

--- a/src/SitecoreCecSearchModule/functions/connectors-serialization.ps1
+++ b/src/SitecoreCecSearchModule/functions/connectors-serialization.ps1
@@ -109,6 +109,11 @@ function Read-CecConnector {
     $connector = Get-Content $connectorPath | ConvertFrom-Json
 
     if (-not $SkipFiles) {
+
+        if (-not $connector.content.PSObject.Properties.Name.Contains("crawler")) {
+            continue
+        }
+        
         $crawlerTypes = @("webCrawlerConfig", "apiCrawlerConfig")
         foreach ($crawlerType in $crawlerTypes) {
             if (-not $connector.content.crawler.PSObject.Properties.Name.Contains($crawlerType)) {

--- a/src/SitecoreCecSearchModule/functions/namesuffixes.ps1
+++ b/src/SitecoreCecSearchModule/functions/namesuffixes.ps1
@@ -30,15 +30,21 @@ function Add-Suffix {
     Param(
         [string]$Value,
         [string]$Prefix,
-        [string]$Suffix
+        [string]$Suffix,
+        [switch]$AddSpace
     )
 
+    $spacer = ""
+    if($AddSpace) {
+        $spacer = " "
+    }
+
     if ("${Prefix}" -ne "") {
-        $Value = $Prefix + $Value
+        $Value = $Prefix + $spacer + $Value
     }
 
     if ("${Suffix}" -ne "") {
-        $Value = $Value + $Suffix
+        $Value = $Value + $spacer + $Suffix
     }
 
     $Value
@@ -52,13 +58,25 @@ function Add-SuffixTemplate {
     )
 
     if ("${Prefix}" -ne "" -and $Value.StartsWith($Prefix)) {
-        $Value = "{Prefix}_" + $Value.Substring($Prefix.Length)
+        $Value = "{Prefix}" + $Value.Substring($Prefix.Length)
     }
 
     if ("${Suffix}" -ne "" -and $Value.EndsWith($Suffix)) {
-        $Value = $Value.Substring(0, $Value.Length - $Suffix.Length) + "_{Suffix}"
+        $Value = $Value.Substring(0, $Value.Length - $Suffix.Length) + "{Suffix}"
     }
 
     $Value
+}
 
+function Set-SuffixTemplateValues {
+    Param(
+        [Parameter(ValueFromPipeline, Mandatory)]
+        [string]$Value,
+        [string]$Prefix,
+        [string]$Suffix
+    )
+
+    $Value = $Value.Replace("{Prefix}", $Prefix).Replace("{Suffix}", $Suffix)
+
+    $Value
 }

--- a/src/SitecoreCecSearchModule/functions/namesuffixes.ps1
+++ b/src/SitecoreCecSearchModule/functions/namesuffixes.ps1
@@ -8,7 +8,7 @@ function SuffixIsSpecified {
 }
 
 function Remove-Suffix {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Scope='Function')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Scope = 'Function')]
     Param(
         [string]$Value,
         [string]$Prefix,
@@ -35,7 +35,7 @@ function Add-Suffix {
     )
 
     $spacer = ""
-    if($AddSpace) {
+    if ($AddSpace) {
         $spacer = " "
     }
 
@@ -68,7 +68,8 @@ function Add-SuffixTemplate {
     $Value
 }
 
-function Set-SuffixTemplateValues {
+function Set-SuffixTemplateValue {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'false positive')]
     Param(
         [Parameter(ValueFromPipeline, Mandatory)]
         [string]$Value,
@@ -76,7 +77,9 @@ function Set-SuffixTemplateValues {
         [string]$Suffix
     )
 
-    $Value = $Value.Replace("{Prefix}", $Prefix).Replace("{Suffix}", $Suffix)
+    process {
+        $Value = $Value.Replace("{Prefix}", $Prefix).Replace("{Suffix}", $Suffix)
 
-    $Value
+        $Value
+    }
 }

--- a/src/scripts/pull-all.ps1
+++ b/src/scripts/pull-all.ps1
@@ -22,4 +22,4 @@ $domains = @{
 }
 
 Write-Host "Exporting to $Path ..."
-Invoke-GetAndWriteAllCecConfiguration -Path $Path -EnvToken $EnvName -Domains $domains
+Invoke-GetAndWriteAllCecConfiguration -Path $Path -EnvToken $EnvName -Domains $domains -EntityPrefix "${EnvName}".ToLower()


### PR DESCRIPTION
Read entities from Sitecore Search with `Get-CecEntityConfig` and `Get-CecEntity`
Serialization of entities with `Read` and `Write` methods and update with `Set` methods

`Add-CecConnectorPrefix` and `Remove-CecConnectorPrefix` updated with `EntityPrefix` and `EntitySuffix` arguments to change taggers

Updated `Invoke-GetAndWriteAllCecConfiguration` and `Invoke-GetAndWriteCecConnectorConfiguration` updated with `EntityPrefix` and `EntitySuffix` arguments
